### PR TITLE
chore: update endpoints from `/wapi` to `/sapi`

### DIFF
--- a/lib/binance/client/rest/clients.rb
+++ b/lib/binance/client/rest/clients.rb
@@ -34,7 +34,7 @@ module Binance
       end
 
       def public_withdraw_client(adapter, proxy=nil)
-        Faraday.new(url: "#{BASE_URL}/wapi") do |conn|
+        Faraday.new(url: "#{BASE_URL}/sapi") do |conn|
           conn.request :json
           conn.response :json, content_type: /\bjson$/
           conn.adapter adapter
@@ -43,7 +43,7 @@ module Binance
       end
 
       def withdraw_client(api_key, secret_key, adapter, proxy=nil)
-        Faraday.new(url: "#{BASE_URL}/wapi") do |conn|
+        Faraday.new(url: "#{BASE_URL}/sapi") do |conn|
           conn.request :url_encoded
           conn.response :json, content_type: /\bjson$/
           conn.headers['X-MBX-APIKEY'] = api_key

--- a/lib/binance/client/rest/endpoints.rb
+++ b/lib/binance/client/rest/endpoints.rb
@@ -26,14 +26,14 @@ module Binance
         user_data_stream: 'v1/userDataStream',
 
         # Withdraw API Endpoints
-        withdraw:         'v3/withdraw.html',
-        deposit_history:  'v3/depositHistory.html',
-        withdraw_history: 'v3/withdrawHistory.html',
-        deposit_address:  'v3/depositAddress.html',
-        account_status:   'v3/accountStatus.html',
-        system_status:    'v3/systemStatus.html',
+        withdraw:         'v1/capital/withdraw/apply',
+        deposit_history:  'v1/capital/deposit/hisrec',
+        withdraw_history: 'v1/capital/withdraw/history',
+        deposit_address:  'v1/capital/deposit/address',
+        account_status:   'v1/account/status',
+        system_status:    'v1/system/status',
         withdraw_fee:     'v3/withdrawFee.html',
-        dust_log:         'v3/userAssetDribbletLog.html',
+        dust_log:         'v1/asset/dribblet',
 
         # Broker API Endpoints
         # https://binance-docs.github.io/Brokerage-API/General/
@@ -46,7 +46,7 @@ module Binance
         sub_account_bnb_burn:        'v1/broker/subAccount/bnbBurn/spot',
         sub_account_bnb_burn_status: 'v1/broker/subAccount/bnbBurn/status',
         sub_account_transfer:        'v1/broker/transfer',
-        sub_account_deposit_address: 'v3/depositAddress.html',
+        sub_account_deposit_address: 'v1/capital/deposit/address',
         sub_account_deposit_history: 'v1/broker/subAccount/depositHistory',
         sub_account_balances:        'v1/broker/subAccount/spotSummary'
       }.freeze


### PR DESCRIPTION
Some of our withdrawals have been failing due to some API changes from Binance's side. The peculiar thing is that it's only happening to some withdrawals and not all, which is weird since all withdrawals are still using the deprecated API. In any case, this is the change in the client to use the new updated API endpoints.

Example failed withdrawal: https://bloomx.app/admin/withdrawals/17427

> This endpoint has been deprecated, please integrate with “POST@/sapi/v1/capital/withdraw/apply”. See details in the announcement: https://www.binance.com/en/support/announcement/f45dde7da58b473aa885349946bed269